### PR TITLE
don't attribute authors who have referenced the pull request

### DIFF
--- a/src/changelog-generator.js
+++ b/src/changelog-generator.js
@@ -157,6 +157,9 @@ function encodedStr(rawStr)
 
 function formatChangelogEntry(issue, authors)
 {
+    authors = authors.filter(function (item, pos, self) {
+        return self.indexOf(item) === pos;
+    });
     var description = '<a href="' + issue.html_url + '">#' + issue.number + '</a> ' + encodedStr(issue.title);
 
     if (authors.length) {
@@ -364,7 +367,7 @@ function getCommitter(issue, page)
         success : function(result, xhr) {
 
             $.each(result, function (index, event) {
-                if (event.event != 'referenced' && event.event != 'closed' && event.event != 'assigned') {
+                if (event.event != 'closed' && event.event != 'assigned' && event.event != 'merged') {
                     // we want to list only authors who have contributed code
                     return;
                 }


### PR DESCRIPTION
Otherwise people who mention a pull request in commit show up as and author (or if author and merger of a pull request is the same person, he appears twice)