### PR TITLE
Automatically ignore issues that were closed as not planned on GitHub

### DIFF
--- a/src/changelog-generator.js
+++ b/src/changelog-generator.js
@@ -181,6 +181,11 @@ function fetchIssuesBetween (repository, issues, startIsoDate, endIsoDate, page)
 
             $.each(result, function (index, issue) {
 
+                if (issue.state_reason === "not_planned") {
+                    console.log('ignore this issue because it was closed as not planned', issue);
+                    return;
+                }
+
                 if (hasIssueAnIgnoredLabel(issue)) {
                     return;
                 }


### PR DESCRIPTION
### Description:

GitHub meanwhile has the possibility to either close issues as completed or as not planned. Issues closed as not planned should never occur in the changelog.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
